### PR TITLE
Add navigation menu with placeholder pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,13 @@
+main:
+  - title: "Home"
+    url: /
+  - title: "Call for Papers"
+    url: /call-for-papers/
+  - title: "Invited Talks"
+    url: /invited-talks/
+  - title: "Program"
+    url: /program/
+  - title: "Organizers"
+    url: /organizers/
+  - title: "Registration"
+    url: /registration/

--- a/call-for-papers.md
+++ b/call-for-papers.md
@@ -1,0 +1,7 @@
+---
+title: "Call for Papers"
+permalink: /call-for-papers/
+layout: single
+---
+
+Information about paper submissions will appear here.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 title: "WCCA 2025 Workshop"
+permalink: /
 layout: single
 ---
 

--- a/invited-talks.md
+++ b/invited-talks.md
@@ -1,0 +1,7 @@
+---
+title: "Invited Talks"
+permalink: /invited-talks/
+layout: single
+---
+
+Details on invited speakers and talks will appear here.

--- a/organizers.md
+++ b/organizers.md
@@ -1,0 +1,7 @@
+---
+title: "Organizers"
+permalink: /organizers/
+layout: single
+---
+
+Details about the workshop organizers will appear here.

--- a/program.md
+++ b/program.md
@@ -1,0 +1,7 @@
+---
+title: "Program"
+permalink: /program/
+layout: single
+---
+
+The program schedule will be posted here.

--- a/registration.md
+++ b/registration.md
@@ -1,0 +1,7 @@
+---
+title: "Registration"
+permalink: /registration/
+layout: single
+---
+
+Registration instructions will be provided here.


### PR DESCRIPTION
## Summary
- add navigation config for top menu
- create placeholder pages for Call for Papers, Invited Talks, Program, Organizers, and Registration
- update index front matter with permalink

## Testing
- `jekyll build` *(fails: command not found)*